### PR TITLE
Add parens around converse implication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Are you unimpressed by these wats? Do you think these edge cases are actually co
 
 ### The undocumented [converse implication](https://en.wikipedia.org/wiki/Converse_implication) operator
 
-    >>> False ** False == True
+    >>> (False ** False) == True
     True
-    >>> False ** True == False
+    >>> (False ** True) == False
     True
-    >>> True ** False == True
+    >>> (True ** False) == True
     True
-    >>> True ** True == True
+    >>> (True ** True) == True
     True
 
 ### Mixing numerical types


### PR DESCRIPTION
I think this is right, and I think it increases readability. Not being familiar with the operator, I didn't know the precedence, and so didn't know how to parse the example.

Alternatively, I think you could eliminate the `== bool` term, since the next line gives the value of the expression.
